### PR TITLE
Fixed alignment of dt elements

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -58,6 +58,7 @@ h3 {
 }
 
 dt {
+    clear: both;
     float: left;
     font-weight: bold;
 }


### PR DESCRIPTION
Sometimes these were misaligned in Chrome; think I've fixed it and have checked in Chrome, FF and IE.
