### PR TITLE
Removed email link

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,8 +53,7 @@
             like to share at a future event, we'd love to hear from you.
         </p>
         <p>
-            Contact us via <a href="mailto:info@unifieddiff.co.uk">info@unifieddiff.co.uk</a>
-            or Twitter - <a href="http://twitter.com/unifieddiff">@unifieddiff</a>
+            Contact us via Twitter - <a href="http://twitter.com/unifieddiff">@unifieddiff</a>
         </p>
     </body>
 </html>


### PR DESCRIPTION
The email link wasn't going anywhere so I've removed it in case people try contacting us through it. We need to either fix it so it works, or set up another email address in Gmail or whatever.
