### PR TITLE
Added clean code video

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,10 +45,10 @@
             <p>We had a great turnout for the first event.  All talks were received
             very well, massive thanks to the speakers and to everyone who made the
             trip to attend.</p>
-            <p>Video recordings of the tech talks given will be available very soon. Here's a taster!</p>
+            <p>Video recordings of the remaining tech talks will be available very soon.</p>
             <div class="read-more">
                 
-                <a id="taster"><iframe src="//player.vimeo.com/video/36267777?title=0&amp;byline=0&amp;portrait=0" width="450" height="300" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe><p><a href="http://vimeo.com/36267777">Unified Diff - 1st Feb 2012</a> from <a href="http://vimeo.com/user7999622">Suma Pugh</a> on <a href="http://vimeo.com">Vimeo</a>.</p></a>
+                <a id="taster"><iframe src="//player.vimeo.com/video/36267777?title=0&amp;byline=0&amp;portrait=0" width="450" height="300" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe><p><a href="http://vimeo.com/36267777">Unified Diff - 1st Feb 2012</a> from <a href="http://vimeo.com/user7999622">Suma Pugh</a> on <a href="http://vimeo.com">Vimeo</a>.</p></a>                
                 
                 <dl>
                     <dt>19:00</dt>
@@ -63,9 +63,11 @@
                     </dd>
                     <dt>20:00</dt>
                     <dd>
-                        <strong>Clean Code</strong><br/>
-                        Gavin Davies - <a href="http://twitter.com/gavd_uk" target="new">@gavd_uk</a> - source code available
-                        at <a href="https://github.com/gavD/refactoring-to-clean-code">https://github.com/gavD/refactoring-to-clean-code</a>
+                        <strong>Clean Code</strong><br />
+                        Gavin Davies - <a href="http://twitter.com/gavd_uk" target="new">@gavd_uk</a>
+                        <a id="clean-code"><iframe src="//player.vimeo.com/video/36714130?title=0&amp;byline=0&amp;portrait=0" width="450" height="300" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe><p><a href="http://vimeo.com/36267777">Clean Code</a> on <a href="http://vimeo.com">Vimeo</a>.</p></a>
+                        <p>source code available
+                        at <a href="https://github.com/gavD/refactoring-to-clean-code">https://github.com/gavD/refactoring-to-clean-code</a></p>
                     </dd>
                     <dt>20:30</dt>
                     <dd>


### PR DESCRIPTION
Just added to the homepage for now, we need to sort an event archive / videos page out though.

URL to the video is http://unifieddiff.co.uk/#clean-code if someone wants to tweet that
