### PR TITLE
Bring videos annotation down a few pixels so it pointing to videos link ...

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -44,7 +44,7 @@ h2:before {
 div.container {
     background-image: url(../img/videos.png);
     background-repeat: no-repeat;
-    background-position: 500px 105px;
+    background-position: 500px 145px;
 }
 
 section:nth-of-type(odd) h2 {


### PR DESCRIPTION
...more accurately

---

Noticed the videos arrow wasn't actually pointing at the link. Tested in latest Chrome & Safari on OSX only.
